### PR TITLE
Accordion was not working on Redmine-2.0.3

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,7 +11,7 @@ class RedmineProjectsAccordionListener < Redmine::Hook::ViewListener
 
   # Adds javascript and stylesheet tags
   def view_layouts_base_html_head(context)
-    javascript_include_tag('accordion', :plugin => :projects_tree_view) +
+    javascript_include_tag('accordion', :plugin => :redmine_projects_accordion) +
     javascript_include_tag('redmine_projects_accordion', :plugin => :redmine_projects_accordion) +
     stylesheet_link_tag('redmine_projects_accordion', :plugin => :redmine_projects_accordion)
   end


### PR DESCRIPTION
Hello, 

First I want to thanks for creating the plugin, and opennig it... :smile:

I've cloned your plugin, but unfortunely it wasn't working properly on my version of redmine. So I've noticed that the problem was that it was referencing other plugin on the init.rb (projects_tree_view), once I changed to your plugins it started to works.

it was necesery to have the projects_tree_view plugin to work properly?
